### PR TITLE
prevent unexpected crashes

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -2,7 +2,7 @@
 #import <substrate.h>
 #import "PHController.h"
 
-#define DEBUG
+// #define DEBUG
 
 #ifndef DEBUG
 #define NSLog 


### PR DESCRIPTION
sometimes [controller curAppID] is returned in other than NSString. (NSArray, CALayer, and so on)
principle is unknown, but I made ​​a simple avoidance.
This phenomenon has occurred in many people..

```
Jun 22 21:47:50 iPhone5s SpringBoard[2376]: TWEAK.XM OBSERVER ADD BULLETIN
Jun 22 21:47:51 iPhone5s SpringBoard[2376]: TABLEVIEW HEIGHT FOR ROW AT INDEXPATH
Jun 22 21:47:51 iPhone5s SpringBoard[2376]: ITEM: <SBAwayBulletinListItem: 0x1706c1ea0>: 1 bulletins
Jun 22 21:47:51 iPhone5s SpringBoard[2376]: -[__NSArrayM isEqualToString:]: unrecognized selector sent to instance 0x170c46690
Jun 22 21:47:51 iPhone5s SpringBoard[2376]: ***** Uncaught Exception: -[__NSArrayM isEqualToString:]: unrecognized selector sent to instance 0x170c46690 *****
```
